### PR TITLE
Fix package.json syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "DreadScripts",
     "DreadTools",
     "VRChat",
-	"ChilloutVR"
-	"Tool",
+    "ChilloutVR",
+    "Tool",
     "Converter",
     "Conversion",
-	"DynamicBone"
+    "DynamicBone"
   ],
   "author": {
     "name": "Dreadrith",


### PR DESCRIPTION
Was missing a comma after "ChilloutVR". Replaced tabs with spaces.